### PR TITLE
TOPページのスワイパー中央寄せ

### DIFF
--- a/app/assets/stylesheets/modules/items.scss
+++ b/app/assets/stylesheets/modules/items.scss
@@ -145,9 +145,13 @@
 }
 
 .top-carousel {
+  width: 100%;
   height: 200px;
   position: relative;
   overflow: hidden;
+  .swiper-slide {
+    text-align: center;
+  }
   .swiper-button-custome {
     background-image: none !important;
     margin: 0 35px;


### PR DESCRIPTION
# WHAT
大画面で見たときにスワイパーが左寄せで表示されるのを中央に寄せる

# WHY
画像サイズより大きい画面上だとビューの見た目が崩れるため